### PR TITLE
修复解析自包含对象，报栈溢出的问题

### DIFF
--- a/src/main/java/org/word/service/impl/WordServiceImpl.java
+++ b/src/main/java/org/word/service/impl/WordServiceImpl.java
@@ -211,6 +211,10 @@ public class WordServiceImpl implements WordService {
                 if ("array".equals(keyMap.get("type"))) {
                     //数组的处理方式
                     String sonRef = (String) ((Map) keyMap.get("items")).get("$ref");
+                    //对象自包含，跳过解析
+                    if(ref.equals(sonRef)){
+                        continue;
+                    }
                     JsonNode jsonNode = parseRef(sonRef, map);
                     ArrayNode arrayNode = JsonUtils.createArrayNode();
                     arrayNode.add(jsonNode);
@@ -218,6 +222,10 @@ public class WordServiceImpl implements WordService {
                 } else if (keyMap.get("$ref") != null) {
                     //对象的处理方式
                     String sonRef = (String) keyMap.get("$ref");
+                    //对象自包含，跳过解析
+                    if(ref.equals(sonRef)){
+                        continue;
+                    }
                     ObjectNode object = parseRef(sonRef, map);
                     objectNode.set(key, object);
                 } else {


### PR DESCRIPTION
对象自包含会报栈溢出错误，例如如下json部分：
<pre>
	"RegionDTO": {
			"type": "object",
			"properties": {
				"children": {
					"type": "array",
					"items": {
						"$ref": "#/definitions/RegionDTO"
					}
				},
				"code": {
					"type": "string"
				},
				"id": {
					"type": "string"
				},
				"name": {
					"type": "string"
				}
			},
			"title": "RegionDTO"
		},
<pre>
增加判断，并自测生效。