### PR TITLE
对复杂返回类型（多层泛型嵌套）进行递归解析，word.html递归生成行

### DIFF
--- a/src/main/java/org/word/service/impl/WordServiceImpl.java
+++ b/src/main/java/org/word/service/impl/WordServiceImpl.java
@@ -239,39 +239,59 @@ public class WordServiceImpl implements WordService {
             Iterator<String> modelNameIt = definitions.keySet().iterator();
             while (modelNameIt.hasNext()) {
                 String modeName = modelNameIt.next();
-                Map<String, Object> modeProperties = (Map<String, Object>) definitions.get(modeName).get("properties");
-                if (modeProperties == null) {
-                    continue;
-                }
-                Iterator<Entry<String, Object>> mIt = modeProperties.entrySet().iterator();
-
-                List<ModelAttr> attrList = new ArrayList<>();
-
-                //解析属性
-                while (mIt.hasNext()) {
-                    Entry<String, Object> mEntry = mIt.next();
-                    Map<String, Object> attrInfoMap = (Map<String, Object>) mEntry.getValue();
-                    ModelAttr modeAttr = new ModelAttr();
-                    modeAttr.setName(mEntry.getKey());
-                    modeAttr.setType((String) attrInfoMap.get("type"));
-                    if (attrInfoMap.get("format") != null) {
-                        modeAttr.setType(modeAttr.getType() + "(" + attrInfoMap.get("format") + ")");
-                    }
-                    modeAttr.setType(StringUtils.defaultIfBlank(modeAttr.getType(), "object"));
-                    modeAttr.setDescription((String) attrInfoMap.get("description"));
-                    attrList.add(modeAttr);
-                }
-
-                ModelAttr modeAttr = new ModelAttr();
-                Object title = definitions.get(modeName).get("title");
-                Object description = definitions.get(modeName).get("description");
-                modeAttr.setClassName(title == null ? "" : title.toString());
-                modeAttr.setDescription(description == null ? "" : description.toString());
-                modeAttr.setProperties(attrList);
-                definitinMap.put("#/definitions/" + modeName, modeAttr);
+                getAndPutModelAttr(definitions, definitinMap, modeName);
             }
         }
         return definitinMap;
+    }
+
+    /**
+     * 递归生成ModelAttr
+     * 对$ref类型设置具体属性
+     */
+    private ModelAttr getAndPutModelAttr(Map<String, Map<String, Object>> swaggerMap, Map<String, ModelAttr> resMap, String modeName) {
+        if (resMap.get(modeName) != null) {
+            return resMap.get("#/definitions/" + modeName);
+        }
+        Map<String, Object> modeProperties = (Map<String, Object>) swaggerMap.get(modeName).get("properties");
+        if (modeProperties == null) {
+            return null;
+        }
+        Iterator<Entry<String, Object>> mIt = modeProperties.entrySet().iterator();
+
+        List<ModelAttr> attrList = new ArrayList<>();
+        //解析属性
+        while (mIt.hasNext()) {
+            Entry<String, Object> mEntry = mIt.next();
+            Map<String, Object> attrInfoMap = (Map<String, Object>) mEntry.getValue();
+            ModelAttr modeAttr = new ModelAttr();
+            modeAttr.setName(mEntry.getKey());
+            modeAttr.setType((String) attrInfoMap.get("type"));
+            if (attrInfoMap.get("format") != null) {
+                modeAttr.setType(modeAttr.getType() + "(" + attrInfoMap.get("format") + ")");
+            }
+            Object ref = attrInfoMap.get("$ref");
+            Object items = attrInfoMap.get("items");
+            if (ref != null || (items != null && (ref = ((Map)items).get("$ref")) != null)) {
+                String refName = ref.toString();
+                //截取 #/definitions/ 后面的
+                String clsName = refName.substring(14);
+                ModelAttr refModel = getAndPutModelAttr(swaggerMap, resMap, clsName);
+                modeAttr.setProperties(refModel.getProperties());
+            }
+            modeAttr.setType(StringUtils.defaultIfBlank(modeAttr.getType(), "object"));
+            modeAttr.setDescription((String) attrInfoMap.get("description"));
+            attrList.add(modeAttr);
+        }
+        //BaseResult«PageData«DopAppRecordVo»»
+        ModelAttr modeAttr = new ModelAttr();
+        Object title = swaggerMap.get(modeName).get("title");
+        Object description = swaggerMap.get(modeName).get("description");
+        modeAttr.setClassName(title == null ? "" : title.toString());
+        modeAttr.setDescription(description == null ? "" : description.toString());
+        modeAttr.setProperties(attrList);
+        resMap.put("#/definitions/" + modeName, modeAttr);
+        return modeAttr;
     }
 
     /**

--- a/src/main/resources/templates/word.html
+++ b/src/main/resources/templates/word.html
@@ -136,11 +136,8 @@
                     <td colspan="2">说明</td>
                 </tr>
 
-                <tr align="center" th:each="response:${table.modelAttr.properties}">
-                    <td th:text="${response.name}"></td>
-                    <td colspan="2" th:text="${response.type}"></td>
-                    <td colspan="2" th:text="${response.description}"></td>
-                </tr>
+<!--               对返回参数 递归生成行-->
+                <tbody th:include="this::response(${table.modelAttr.properties},'', 1)"/>
 
                 <tr class="bg">
                     <td colspan="5">示例</td>
@@ -158,5 +155,18 @@
         </div>
     </div>
 </div>
+
+<th:block th:fragment="response(properties,count, lv)">
+    <th:block th:each="p,c : ${properties}">
+        <tr align="center">
+            <td align="left" th:text="${count} + '' + ${c.count} + '.' + ${p.name}"
+                th:style="|padding-left:${10*lv}px|"></td>
+            <td colspan="2" th:text="${p.type}"></td>
+            <td colspan="2" th:text="${p.description}"></td>
+        </tr>
+        <th:block th:unless="${#lists.isEmpty(p.properties)}"
+                  th:include="this::response(${p.properties},${count} + '' + ${c.count} + '.',${lv+1})"/>
+    </th:block>
+</th:block>
 </body>
 </html>


### PR DESCRIPTION
对返回值如：BaseResult<PageData<Student>>，只会解析第一层BaseResult，修改部分代码能递归解析