### PR TITLE
添加使用json字符串和json文件来直接下载doc文件的API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,7 @@
     <properties>
         <skipTests>true</skipTests>
         <java.version>1.8</java.version>
+        <springfox-version>2.6.1</springfox-version>
     </properties>
 
     <dependencies>
@@ -43,6 +44,20 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.springfox</groupId>
+            <artifactId>springfox-swagger2</artifactId>
+            <version>${springfox-version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.springfox</groupId>
+            <artifactId>springfox-swagger-ui</artifactId>
+            <version>${springfox-version}</version>
+        </dependency>
+        <dependency>
+            <groupId>joda-time</groupId>
+            <artifactId>joda-time</artifactId>
         </dependency>
     </dependencies>
     <build>

--- a/src/main/java/org/word/Application.java
+++ b/src/main/java/org/word/Application.java
@@ -2,6 +2,7 @@ package org.word;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import springfox.documentation.swagger2.annotations.EnableSwagger2;
 
 /**
  * @author cuixiuyin
@@ -9,6 +10,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
  * @date: 2018/12/19 21:32
  */
 @SpringBootApplication
+@EnableSwagger2
 public class Application {
 
     public static void main(String[] args) {

--- a/src/main/java/org/word/config/SwaggerDocumentationConfig.java
+++ b/src/main/java/org/word/config/SwaggerDocumentationConfig.java
@@ -1,0 +1,46 @@
+package org.word.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import springfox.documentation.builders.ApiInfoBuilder;
+import springfox.documentation.builders.RequestHandlerSelectors;
+import springfox.documentation.service.ApiInfo;
+import springfox.documentation.service.ApiKey;
+import springfox.documentation.service.Contact;
+import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spring.web.plugins.Docket;
+
+import java.util.Collections;
+import java.util.List;
+
+/*
+ * added by dongxl6
+ * enable swagger-ui
+ */
+@Configuration
+public class SwaggerDocumentationConfig {
+
+    ApiInfo apiInfo() {
+        return new ApiInfoBuilder()
+            .title("Swagger to Word")
+            .description("a tool for converting swagger json to word")
+            .license("Apache 2.0")
+            .licenseUrl("http://www.apache.org/licenses/LICENSE-2.0.html")
+            .termsOfServiceUrl("")
+            .version("0.0.1")
+            .contact(new Contact("","", "15980292662@163.com"))
+            .build();
+    }
+
+    @Bean
+    public Docket customImplementation(){
+        return new Docket(DocumentationType.SWAGGER_2)
+                .select()
+                    .apis(RequestHandlerSelectors.basePackage("org.word.controller"))
+                    .build()
+                .directModelSubstitute(org.joda.time.LocalDate.class, java.sql.Date.class)
+                .directModelSubstitute(org.joda.time.DateTime.class, java.util.Date.class)
+                .apiInfo(apiInfo());
+    }
+
+}

--- a/src/main/java/org/word/controller/IndexController.java
+++ b/src/main/java/org/word/controller/IndexController.java
@@ -1,8 +1,14 @@
 package org.word.controller;
 
 
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import org.springframework.core.io.Resource;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import springfox.documentation.annotations.ApiIgnore;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -13,10 +19,9 @@ import javax.servlet.http.HttpServletRequest;
  */
 @Controller
 public class IndexController {
-
-
-    @RequestMapping("/")
+    @ApiIgnore
+    @RequestMapping(value = "/")
     public String index(HttpServletRequest request) {
-        return "index";
+        return "redirect:swagger-ui.html";
     }
 }

--- a/src/main/java/org/word/controller/WordController.java
+++ b/src/main/java/org/word/controller/WordController.java
@@ -1,17 +1,23 @@
 package org.word.controller;
 
+import io.swagger.annotations.*;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.client.RestTemplate;
+import org.springframework.web.multipart.MultipartFile;
+import org.thymeleaf.context.Context;
+import org.thymeleaf.spring5.SpringTemplateEngine;
 import org.word.service.WordService;
 
 import javax.servlet.http.HttpServletResponse;
+import javax.validation.Valid;
 import java.io.BufferedOutputStream;
 import java.io.IOException;
 import java.net.URLEncoder;
@@ -21,6 +27,10 @@ import java.util.Map;
  * Created by XiuYin.Cui on 2018/1/11.
  */
 @Controller
+@Api(
+        value = "Word",
+        description = "the toWord API"
+)
 public class WordController {
 
     @Autowired
@@ -35,6 +45,9 @@ public class WordController {
     @Value("${server.port}")
     private Integer port;
 
+    @Autowired
+    SpringTemplateEngine springTemplateEngine;
+
     /**
      * 将 swagger 文档转换成 html 文档，可通过在网页上右键另存为 xxx.doc 的方式转换为 word 文档
      *
@@ -43,31 +56,51 @@ public class WordController {
      * @return
      */
     @Deprecated
-    @RequestMapping("/toWord")
-    public String getWord(Model model, @RequestParam(value = "url", required = false) String url,
-                          @RequestParam(value = "download", required = false, defaultValue = "1") Integer download) {
+    @ApiOperation(value = "将 swagger 文档转换成 html 文档，可通过在网页上右键另存为 xxx.doc 的方式转换为 word 文档", notes = "", response = String.class, tags = {
+            "Word"})
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "请求成功。", response = String.class)})
+    @RequestMapping(value = "/toWord",method = {RequestMethod.GET})
+    public String getWord(Model model, @ApiParam(value = "资源地址",required = false)  @RequestParam(value = "url", required = false) String url,
+                          @ApiParam(value = "是否下载",required = false) @RequestParam(value = "download", required = false, defaultValue = "1") Integer download) {
+        generateModelData(model, url, download);
+        return "word";
+    }
+
+    private void generateModelData(Model model, String url, Integer download) {
         url = StringUtils.defaultIfBlank(url, swaggerUrl);
         Map<String, Object> result = tableService.tableList(url);
         model.addAttribute("url", url);
         model.addAttribute("download", download);
         model.addAllAttributes(result);
-        return "word";
     }
 
     /**
      * 将 swagger 文档一键下载为 doc 文档
-     *
+     * @param model
      * @param url      需要转换成 word 文档的资源地址
      * @param response
      */
-    @RequestMapping("/downloadWord")
-    public void word(@RequestParam(required = false) String url, HttpServletResponse response) {
-        ResponseEntity<String> forEntity = restTemplate.getForEntity("http://localhost:" + port + "/toWord?download=0&url=" + StringUtils.defaultIfBlank(url, swaggerUrl), String.class);
+    @ApiOperation(value = "将 swagger 文档一键下载为 doc 文档", notes = "",  tags = {
+            "Word"})
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "请求成功。")})
+    @RequestMapping(value = "/downloadWord",method = {RequestMethod.GET})
+    public void word(Model model,@ApiParam(value = "资源地址",required = false)  @RequestParam(required = false) String url, HttpServletResponse response) {
+        //ResponseEntity<String> forEntity = restTemplate.getForEntity("http://localhost:" + port + "/toWord?download=0&url=" + StringUtils.defaultIfBlank(url, swaggerUrl), String.class);
+        generateModelData(model, url, 0);
+        writeContentToResponse(model, response);
+    }
+
+    private void writeContentToResponse(Model model, HttpServletResponse response) {
+        Context context = new Context();
+        context.setVariables(model.asMap());
+        String content=springTemplateEngine.process("word",context);
         response.setContentType("application/octet-stream;charset=utf-8");
         response.setCharacterEncoding("utf-8");
         try (BufferedOutputStream bos = new BufferedOutputStream(response.getOutputStream())) {
             response.setHeader("Content-disposition", "attachment;filename=" + URLEncoder.encode("toWord.doc", "utf-8"));
-            byte[] bytes = forEntity.getBody().getBytes();
+            byte[] bytes =content.getBytes();
             bos.write(bytes, 0, bytes.length);
             bos.flush();
         } catch (IOException e) {
@@ -75,5 +108,52 @@ public class WordController {
         }
     }
 
+    /**
+     * 将 swagger json文件转换成 word文档并下载
+     *
+     * @param model
+     * @param jsonFile   需要转换成 word 文档的swagger json文件
+     * @param response
+     * @return
+     */
+    @ApiOperation(value = "将 swagger json文件转换成 word文档并下载", notes = "",  tags = {
+            "Word"})
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "请求成功。")})
+    @RequestMapping(value = "/fileToWord",method = {RequestMethod.POST})
+    public void getWord(Model model,  @ApiParam("swagger json file") @Valid @RequestPart("jsonFile") MultipartFile jsonFile, HttpServletResponse response) {
+        generateModelData(model, jsonFile);
+        writeContentToResponse(model, response);
+    }
 
+    /**
+     * 将 swagger json字符串转换成 word文档并下载
+     *
+     * @param model
+     * @param jsonStr   需要转换成 word 文档的swagger json字符串
+     * @param response
+     * @return
+     */
+    @ApiOperation(value = "将 swagger json字符串转换成 word文档并下载", notes = "",  tags = {
+            "Word"})
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "请求成功。")})
+    @RequestMapping(value = "/strToWord",method = {RequestMethod.POST})
+    public void getWord(Model model,  @ApiParam("swagger json string") @Valid @RequestParam("jsonStr") String jsonStr, HttpServletResponse response) {
+        generateModelData(model, jsonStr);
+        writeContentToResponse(model, response);
+    }
+    private void generateModelData(Model model, String jsonStr) {
+        Map<String, Object> result = tableService.tableListFromString(jsonStr);
+        model.addAttribute("url", "http://");
+        model.addAttribute("download",0);
+        model.addAllAttributes(result);
+    }
+
+    private void generateModelData(Model model, MultipartFile jsonFile) {
+        Map<String, Object> result = tableService.tableList(jsonFile);
+        model.addAttribute("url", "http://");
+        model.addAttribute("download",0);
+        model.addAllAttributes(result);
+    }
 }

--- a/src/main/java/org/word/service/WordService.java
+++ b/src/main/java/org/word/service/WordService.java
@@ -1,5 +1,7 @@
 package org.word.service;
 
+import org.springframework.web.multipart.MultipartFile;
+
 import java.util.Map;
 
 /**
@@ -8,4 +10,8 @@ import java.util.Map;
 public interface WordService {
 
     Map<String,Object> tableList(String swaggerUrl);
+
+    Map<String, Object> tableListFromString(String jsonStr);
+
+    Map<String, Object> tableList(MultipartFile jsonFile);
 }


### PR DESCRIPTION
1、添加swagger-ui支持，可以通过访问http://localhost:8080/swagger-ui.html进行接口调试
2、调整了部分实现代码结构
3、将下载文件通过restTemplate进行localhost调用改为通过templateEngine直接渲染
4、添加了使用json字符串和json文件来直接下载doc文件的API